### PR TITLE
Protect liked items from deletion

### DIFF
--- a/public/modules/api.js
+++ b/public/modules/api.js
@@ -16,7 +16,7 @@ class API {
     return this.request("pinned")
   }
   del (filenames) {
-    const filesarray = [].concat(filenames)
+    const filesarray = Array.isArray(filenames) ? filenames : [filenames]
     return this.request("del", filesarray)
   }
   defaults () {

--- a/public/modules/api.js
+++ b/public/modules/api.js
@@ -16,11 +16,8 @@ class API {
     return this.request("pinned")
   }
   del (filenames) {
-    if (Array.isArray(filenames)) {
-      return this.request("del", filenames)
-    } else {
-      return this.request("del", [filenames])
-    }
+    const filesarray = [].concat(filenames)
+    return this.request("del", filesarray)
   }
   defaults () {
     return this.request("defaults")

--- a/public/modules/selection.js
+++ b/public/modules/selection.js
@@ -336,11 +336,10 @@ class Selection {
   async del() {
     const confirmed = confirm(`Delete the selected files from your device (liked files are skipped)?`)
     if (confirmed) {
-      let selected = this.els.filter((el) => !this.#isFavorite(el))
-      let selectedFiles = selected.map((el) => el.getAttribute("data-src"))
-      await this.api.del(selectedFiles)
-      let res = await this.app.db.files.where("file_path").anyOf(selectedFiles).delete()
-
+      let filteredSelection = this.els.filter((el) => !this.#isFavorite(el))
+      let filesToDelete = filteredSelection.map((el) => el.getAttribute("data-src"))
+      await this.api.del(filesToDelete)
+      let res = await this.app.db.files.where("file_path").anyOf(filesToDelete).delete()
 
       // get the next element to focus after deleting
 
@@ -348,7 +347,7 @@ class Selection {
       if (!focusEl) {
         focusEl = this.els[0].previousSibling
       }
-      for(let el of selected) {
+      for(let el of filteredSelection) {
         el.classList.remove("expanded")
         el.classList.add("removed")
         setTimeout(() => {


### PR DESCRIPTION
A solution for https://github.com/cocktailpeanut/breadboard/issues/50. I would've preferred a dialog that allows you to check a box to delete favorites but that gets tricky between breadmachine and breadboard.

Sorry if the style isn't quite matching the original.